### PR TITLE
Combined dot auras for afflock, rogue

### DIFF
--- a/Kui_Nameplates_TargetHelper/auras.lua
+++ b/Kui_Nameplates_TargetHelper/auras.lua
@@ -20,6 +20,11 @@ KuiTargetAuraList = {
 		30108,	-- 	Unstable Affliction
 		48181,	-- 	Haunt
 		27243,	-- 	Seed of Corruption
+		{172,980} -- Corruption + Agony
+		{172,980,48181} -- Corruption + Agony + Haunt
+		{172,980,30108} -- Corruption + Agony + Unstable Affliction
+		{172,980,30108,48181} -- Corruption + Agony + UA + Haunt
+
 	},
 	[267] = {	-- DESTRUCTION WARLOCK
 		157736,	-- Immolate

--- a/Kui_Nameplates_TargetHelper/auras.lua
+++ b/Kui_Nameplates_TargetHelper/auras.lua
@@ -62,6 +62,7 @@ KuiTargetAuraList = {
 	[259] = {	-- ASSASSINATION ROGUE
 		703,	--	Garrote
 		1943,	--	Rupture
+		{703,259} -- Garrote + Rupture
 	},
 	[261] = { 	-- SUBLETY ROGUE
 		195452,	--	Nightblade

--- a/Kui_Nameplates_TargetHelper/auras.lua
+++ b/Kui_Nameplates_TargetHelper/auras.lua
@@ -14,7 +14,7 @@ KuiTargetAuraList = {
 		34914, 	--  Vampiric Touch
 		{589,34914} -- Vampiric Touch + Shadow Word: Pain
 	}, 
-	[265] = {	-- AFFLICATION WARLOCK
+	[265] = {	-- AFFLICTION WARLOCK
 		172,	--	Corruption
 		980,	--	Agony
 		30108,	-- 	Unstable Affliction


### PR DESCRIPTION
Hi there! I was going to submit an issue for combining affliction lock debuffs, but then I thought rather than nickel-and-diming you to death, I could submit a PR. 

first commit fixes the spelling of "affliction"
second commit adds combined auras for afflock
third commit adds combined aura for assassin rogue

Happy to drop commits or make changes, of course.