### PR TITLE
Add demonology warlock T31 DOT tracking.

### DIFF
--- a/Kui_Nameplates_TargetHelper/auras.lua
+++ b/Kui_Nameplates_TargetHelper/auras.lua
@@ -26,7 +26,7 @@ KuiTargetAuraList = {
 		48181,	-- 	Haunt
 		27243,	-- 	Seed of Corruption		
 	},
-	[266] = {   -- DEMONOLOGY WARLOCK
+	[266] = {	-- DEMONOLOGY WARLOCK
 		423583, -- Doom Brand
 	},
 	[267] = {	-- DESTRUCTION WARLOCK

--- a/Kui_Nameplates_TargetHelper/auras.lua
+++ b/Kui_Nameplates_TargetHelper/auras.lua
@@ -26,6 +26,9 @@ KuiTargetAuraList = {
 		48181,	-- 	Haunt
 		27243,	-- 	Seed of Corruption		
 	},
+	[266] = {   -- DEMONOLOGY WARLOCK
+		423583, -- Doom Brand
+	},
 	[267] = {	-- DESTRUCTION WARLOCK
 		157736,	-- Immolate
 		80240,	-- Havoc


### PR DESCRIPTION
Tested locally.

Wowhead reference:  https://www.wowhead.com/spell=423583/doom-brand