### PR TITLE
add support for ret pal (judgment)

### DIFF
--- a/Kui_Nameplates_TargetHelper/auras.lua
+++ b/Kui_Nameplates_TargetHelper/auras.lua
@@ -132,5 +132,8 @@ KuiTargetAuraList = {
 	},
 	[65] = {	-- Paladin (HOLY)
 		287280	-- Glimmer of Light
+	},
+	[70] = {	-- RETRIBUTION PALADIN
+		197277	-- Judgment
 	}
 }


### PR DESCRIPTION
add judgment for ret pals to make it easier to track the damage buff from greater judgment

https://www.wowhead.com/spell=231663/greater-judgment