### PR TITLE
Add option to use default fading for debuff coloring

### DIFF
--- a/Kui_Nameplates_TargetHelper/config.lua
+++ b/Kui_Nameplates_TargetHelper/config.lua
@@ -78,6 +78,7 @@ opt.ui = {
 	preferaura = nil,
 	preferauracustom = nil,
 	disablealpha = nil,
+	fadecoloredenemies = nil,
 	nametext = nil,
 	elitebordercolor = nil,
 	focustargetcolor = nil,
@@ -145,6 +146,7 @@ function mod:LoadMissingValues()
 	SetDefaultValue('TargetScale', 1.0)
 	SetDefaultValue('Priority', 3)
 	SetDefaultValue('DisableAlpha', true)
+	SetDefaultValue('FadeColoredEnemies', false)
 	SetDefaultValue('ColorTarget', false)
 	SetDefaultValue('EnableEliteBorder', true)
 	SetDefaultValue('EnableFocusBorder', true)
@@ -173,6 +175,7 @@ function mod:ResetUi()
 	opt.ui.preferaura:SetChecked(false)
 	opt.ui.preferauracustom:SetChecked(false)
 	opt.ui.disablealpha:SetChecked(false)
+	opt.ui.fadecoloredenemies:SetChecked(false)
 	opt.ui.nametext:SetChecked(false)
 	opt.ui.enableeliteborder:SetChecked(false)
 	opt.ui.enablefocusborder:SetChecked(false)
@@ -206,6 +209,7 @@ function mod:ReloadValues(spec_changed)
 	opt.ui.preferaura:SetChecked(opt.env.PreferAura)
 	opt.ui.preferauracustom:SetChecked(opt.env.PreferAuraCustom)
 	opt.ui.disablealpha:SetChecked(opt.env.DisableAlpha)
+	opt.ui.fadecoloredenemies:SetChecked(opt.env.FadeColoredEnemies)
 	opt.ui.nametext:SetChecked(opt.env.NameText)
 	opt.ui.enableeliteborder:SetChecked(opt.env.EnableEliteBorder)
 	opt.ui.enablefocusborder:SetChecked(opt.env.EnableFocusBorder)

--- a/Kui_Nameplates_TargetHelper/localisation.lua
+++ b/Kui_Nameplates_TargetHelper/localisation.lua
@@ -74,6 +74,8 @@ function opt:SetupLocale()
 		PreferAuraCustomTooltip = "When a target is debuffed, prefer to use the Debuff color over the Custom Enemy color.",
 		DisableAlpha = "Disable fade of tracked enemies",
 		DisableAlphaTooltip = "Nameplates in your Enemy Color list will always be shown with full opacity.",
+		FadeColoredEnemies = "Use default fading rules for debuff coloring",
+		FadeColoredEnemiesTooltip = "Nameplates in your Debuff colors list will use default fading rules.",
 		
 		-- custom target contexts
 		ContextCustom = 'Custom',

--- a/Kui_Nameplates_TargetHelper/main.lua
+++ b/Kui_Nameplates_TargetHelper/main.lua
@@ -81,7 +81,7 @@ function mod.Fading_FadeRulesReset()
     plugin_fading:AddFadeRule(function(f)
 		
 		-- non-targets with aura should be drawn
-		if (f.state.hasAura == 1 and opt.env.FadeColoredEnemies) then
+		if (f.state.hasAura == 1 and not opt.env.FadeColoredEnemies) then
 			return 1
 		end
 		

--- a/Kui_Nameplates_TargetHelper/main.lua
+++ b/Kui_Nameplates_TargetHelper/main.lua
@@ -81,7 +81,7 @@ function mod.Fading_FadeRulesReset()
     plugin_fading:AddFadeRule(function(f)
 		
 		-- non-targets with aura should be drawn
-		if (f.state.hasAura == 1) then
+		if (f.state.hasAura == 1 and opt.env.FadeColoredEnemies) then
 			return 1
 		end
 		

--- a/Kui_Nameplates_TargetHelper/panels.lua
+++ b/Kui_Nameplates_TargetHelper/panels.lua
@@ -65,7 +65,7 @@ function mod:CreateMainPanel(parent)
 	))
 	
 	-- top panel
-	opt.ui.toppanel = opt:CreatePanel(parent, "TopFrame", 330, 170)
+	opt.ui.toppanel = opt:CreatePanel(parent, "TopFrame", 330, 180)
 	opt.ui.toppanel:SetPoint('TOPLEFT', 25, -40)
 	
 	opt.ui.topPanelTitle = parent:CreateFontString(nil, 'ARTWORK', 'GameFontNormalLarge')
@@ -75,7 +75,7 @@ function mod:CreateMainPanel(parent)
 	-- target color
 	
 	opt.ui.colortarget = opt:CreateCheckBox(opt.ui.toppanel, 'ColorTarget')
-	opt.ui.colortarget:SetPoint("TOPLEFT", opt.ui.toppanel, "TOPLEFT", 0, -5)
+	opt.ui.colortarget:SetPoint("TOPLEFT", opt.ui.toppanel, "TOPLEFT", 0, 0)
 	opt:AddTooltip(opt.ui.colortarget, opt.titles.ColorTarget, opt.titles.ColorTargetTooltip)
 	
 	opt.ui.targetcolor = opt:CreateColorTexture(opt.ui.toppanel, 'TargetColor', 160, 24,opt.env.TargetColor.r, opt.env.TargetColor.g, opt.env.TargetColor.b, opt.env.TargetColor.a)
@@ -84,7 +84,7 @@ function mod:CreateMainPanel(parent)
 	-- disable in pvp
 	
 	opt.ui.disablepvp = opt:CreateCheckBox(opt.ui.toppanel, 'DisablePvP')
-	opt.ui.disablepvp:SetPoint("TOPLEFT", opt.ui.colortarget, "BOTTOMLEFT", 0, -8)
+	opt.ui.disablepvp:SetPoint("TOPLEFT", opt.ui.colortarget, "BOTTOMLEFT", 0, -5)
 	opt:AddTooltip2(opt.ui.disablepvp, opt.titles.DisablePvP, opt.titles.DisablePvPTooltip)
 	
 	-- recolor target name
@@ -96,18 +96,23 @@ function mod:CreateMainPanel(parent)
 	-- prefer auras over target
 	
 	opt.ui.preferaura = opt:CreateCheckBox(opt.ui.toppanel, 'PreferAura')
-	opt.ui.preferaura:SetPoint("TOPLEFT", opt.ui.disablepvp, "BOTTOMLEFT", 0, -8)
+	opt.ui.preferaura:SetPoint("TOPLEFT", opt.ui.disablepvp, "BOTTOMLEFT", 0, -5)
 	opt:AddTooltip2(opt.ui.preferaura, opt.titles.PreferAura, opt.titles.PreferAuraTooltip)
 	
 	-- prefer auras over custom
 	
 	opt.ui.preferauracustom = opt:CreateCheckBox(opt.ui.toppanel, 'PreferAuraCustom')
-	opt.ui.preferauracustom:SetPoint("TOPLEFT", opt.ui.preferaura, "BOTTOMLEFT", 0, -8)
+	opt.ui.preferauracustom:SetPoint("TOPLEFT", opt.ui.preferaura, "BOTTOMLEFT", 0, -5)
 	opt:AddTooltip2(opt.ui.preferauracustom, opt.titles.PreferAuraCustom, opt.titles.PreferAuraCustomTooltip)
 	
 	opt.ui.disablealpha = opt:CreateCheckBox(opt.ui.toppanel, 'DisableAlpha')
-	opt.ui.disablealpha:SetPoint("TOPLEFT", opt.ui.preferauracustom, "BOTTOMLEFT", 0, -8)
+	opt.ui.disablealpha:SetPoint("TOPLEFT", opt.ui.preferauracustom, "BOTTOMLEFT", 0, -5)
 	opt:AddTooltip2(opt.ui.disablealpha, opt.titles.DisableAlpha, opt.titles.DisableAlphaTooltip)
+	
+	-- fade colored enemies
+	opt.ui.fadecoloredenemies = opt:CreateCheckBox(opt.ui.toppanel, 'FadeColoredEnemies')
+	opt.ui.fadecoloredenemies:SetPoint("TOPLEFT", opt.ui.disablealpha, "BOTTOMLEFT", 0, -5)
+	opt:AddTooltip2(opt.ui.disablealpha, opt.titles.FadeColoredEnemies, opt.titles.FadeColoredEnemiesTooltip)
 	
 	-- 'border options' panel
 	


### PR DESCRIPTION
It would be nice to support "fallback" to baseline KuiNameplate fading rules even when debuff coloring is enabled.

This PR adds support for such functionality via a toggle in the KuiNameplates Target Helper main panel.