### PR TITLE
Fix inconsistent behaviour when enabling/disabling shared settings

### DIFF
--- a/Kui_Nameplates_TargetHelper/config.lua
+++ b/Kui_Nameplates_TargetHelper/config.lua
@@ -439,9 +439,8 @@ function events:PLAYER_LOGOUT()
 		HasSetGlobalData = false
 	end
 	
-	-- store the 'enable global data' flag in both locations. we'll only read from per-character.
+	-- store the 'enable global data' flag per-character.
 	KuiTargetHelperConfigCharSaved.EnableGlobalData = opt.env.EnableGlobalData
-	KuiTargetHelperConfigSaved.EnableGlobalData = opt.env.EnableGlobalData
 	
 	-- do we need to save global data?
 	if (opt.env.EnableGlobalData == true) then


### PR DESCRIPTION
This PR addresses issue #46.

Currently when logging out the configuration option "enable global data" is always written to the global config file, regardless whether it is enabled or disabled. However, when the option is disabled in global data it will actually result in disabling this option for any character on next login.

This PR changes that behaviour so the option is only persisted to global data when it is actually enabled. The per-character behaviour is not affected by this change.